### PR TITLE
Adding GitHub Workflow Parser

### DIFF
--- a/.github/parse_issue.py
+++ b/.github/parse_issue.py
@@ -30,21 +30,27 @@ if not issue:
 body = issue["body"]
 
 # First find the identifier - an md5 hash sum
-identifier = re.search("HelpMe Github Issue: (?P<name>md5.+)", body)
+identifier = re.search("HelpMe Github Issue: (?P<name>.+)", body)
 try:
-    md5 = identifier.groups()[0]
+    identifier = identifier.groups()[0]
 except:
     sys.exit("Error parsing md5 identifier")
 
+# Parse the identifier into folder structure
+parts = identifier.split('-')
+exception_name = parts.pop(0)
+others_md5 = "-".join(parts[0:2])
+datalad_md5 = "-".join(parts[2:4])
+
 # Write the new issue to file, named by the md5
 output_dir = os.path.join(root, "issues")
-issue_dir = os.path.join(output_dir, md5)
+issue_dir = os.path.join(output_dir, exception_name, others_md5, datalad_md5)
 
 exists = True
 for outdir in [output_dir, issue_dir]:
     if not os.path.exists(outdir):
         exists = False
-        os.mkdir(outdir)
+        os.makedirs(outdir)
 
 # For a simple organization, we will store the body of content in a file named
 # by the issue number.

--- a/.github/parse_issue.py
+++ b/.github/parse_issue.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+import json
+import os
+import re
+import requests
+import sys
+
+# Intended to be run in root of repository
+root = os.path.dirname(os.path.abspath(__file__))
+payload_path = os.environ.get("GITHUB_EVENT_PATH")
+if not payload_path:
+    sys.exit("GITHUB_EVENT_PATH not found in environment")
+
+if not os.path.exists(payload_path):
+    sys.exit("%s does not exist!" % payload_path)
+
+payload = json.loads(open(payload_path, "r").read())
+
+# The action should be opened, but we check anyway
+action = payload.get("action", "closed")
+if action != "opened":
+    sys.exit("Issue parsing only happens for newly opened issues.")
+
+# Retrieve the issue, and parse the body
+issue = payload.get("issue")
+if not issue:
+    sys.exit("issue not found in payload.")
+
+body = issue["body"]
+
+# First find the identifier - an md5 hash sum
+identifier = re.search("HelpMe Github Issue: (?P<name>md5.+)", body)
+try:
+    md5 = identifier.groups()[0]
+except:
+    sys.exit("Error parsing md5 identifier")
+
+# Write the new issue to file, named by the md5
+output_dir = os.path.join(root, "issues")
+issue_dir = os.path.join(output_dir, md5)
+
+exists = True
+for outdir in [output_dir, issue_dir]:
+    if not os.path.exists(outdir):
+        exists = False
+        os.mkdir(outdir)
+
+# For a simple organization, we will store the body of content in a file named
+# by the issue number.
+issue_number = issue.get("number")
+output_file = os.path.join(issue_dir, "%s.md" % issue_number)
+
+# If the issue already exists, we will find the first issue that was opened
+if exists:
+    issue_numbers = [int(x.split(".")[0]) for x in os.listdir(outdir)]
+    issue_numbers.sort()
+    if issue_numbers:
+        first_issue = issue_numbers[0]
+
+        # Derive the previous issue url from the current
+        issue_url = "%s/%s" % (
+            "/".join(issue.get("html_url").split("/")[:-1]),
+            first_issue,
+        )
+
+        # Grab variables from the environment
+        token = os.environ.get("GITHUB_TOKEN")
+        repo = os.environ.get("GITHUB_REPOSITORY")
+        issues_url = "https://api.github.com/repos/%s/issues" % repo
+
+        # First, comment on the issue
+        data = {"body": "This issue has already been opened:\n %s" % issue_url}
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": "token %s" % token,
+        }
+        response = requests.post(
+            "%s/%s/comments" % (issues_url, issue_number), headers=headers, json=data
+        )
+
+        print(issues_url)
+        print(data)
+        print(response)
+
+        # If successful, close the new issue
+        if response.status_code in [200, 201]:
+            data = {"state": "closed"}
+            requests.patch(
+                "%s/%s" % (issues_url, issue_number), headers=headers, json=data
+            )
+
+        else:
+            print(response.json())
+            sys.exit("There was a problem commenting on the issue")
+
+
+# More parsing could be done of the content here, but we are going to write to markdown.
+# A more suitable flat format database could likely be used here
+with open(output_file, "w") as filey:
+    filey.writelines("# %s\n" % issue.get("title"))
+    filey.writelines(
+        "Submitted by %s %s\n"
+        % (issue.get("user")["login"], issue.get("author_association"))
+    )
+    filey.writelines(body)

--- a/.github/workflows/report_issue.yml
+++ b/.github/workflows/report_issue.yml
@@ -8,7 +8,7 @@ jobs:
   parseIssue:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup python environment
         run: conda create --quiet --name helpme
       - name: Derive Issue Data
@@ -17,7 +17,9 @@ jobs:
         run: |
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate helpme
-          python .github/parse_issue.py
+          wget https://github.com/datalad/datalad-helpme/blob/17eac96a2692bd05a87b07c42e83d4bf28983ce7/.github/parse_issue.py
+          chmod +x parse_issue.py
+          python parse_issue.py
       - name: Update Upstream Branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report_issue.yml
+++ b/.github/workflows/report_issue.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate helpme
-          wget https://github.com/datalad/datalad-helpme/blob/17eac96a2692bd05a87b07c42e83d4bf28983ce7/.github/parse_issue.py
+          wget https://raw.githubusercontent.com/datalad/datalad-helpme/f650c28f3d949c40dfcb5cf62306cd9301bb219d/.github/parse_issue.py
           chmod +x parse_issue.py
           python parse_issue.py
       - name: Update Upstream Branch

--- a/.github/workflows/report_issue.yml
+++ b/.github/workflows/report_issue.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           export PATH="/usr/share/miniconda/bin:$PATH"
           source activate helpme
-          wget https://raw.githubusercontent.com/datalad/datalad-helpme/f650c28f3d949c40dfcb5cf62306cd9301bb219d/.github/parse_issue.py
+          wget https://raw.githubusercontent.com/datalad/datalad-helpme/80d04b53a4cdb006d8a42a3bc2f083d662de6f14/.github/parse_issue.py
           chmod +x parse_issue.py
           python parse_issue.py
       - name: Update Upstream Branch

--- a/.github/workflows/report_issue.yml
+++ b/.github/workflows/report_issue.yml
@@ -1,0 +1,39 @@
+name: report-issue
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  parseIssue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup python environment
+        run: conda create --quiet --name helpme
+      - name: Derive Issue Data
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export PATH="/usr/share/miniconda/bin:$PATH"
+          source activate helpme
+          python .github/parse_issue.py
+      - name: Update Upstream Branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATE_BRANCH: master
+        run: |
+          echo "GitHub Actor: ${GITHUB_ACTOR}"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git branch
+          echo "Branch to push to is ${UPDATE_BRANCH}"
+          git checkout -b ${UPDATE_BRANCH}
+          git branch
+
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@users.noreply.github.com"
+
+          git pull origin ${UPDATE_BRANCH}
+          git add issues/*
+          git commit -m "Automated deployment to add new issue $(date '+%Y-%m-%d')" --allow-empty
+          git push origin ${UPDATE_BRANCH}

--- a/README.md
+++ b/README.md
@@ -42,18 +42,46 @@ with swallow_outputs() as cmo:
 %s""" % cmo.out
 ```
 
-We will want to add a hash of the problem to this, for the CI to check if the issue
-has been previously opened.
 
-Next, let's run the helper headlessly. Note that this will currently still confirm the
+## Identifier
+
+DataLad is set up to, when submitting an issue using code similar to the above,
+generate it's own identifier that looks like the following:
+
+```
+Exception-others-<md5>-datald-<md5>
+```
+
+Where the components include:
+
+ - the exception class name
+ - an md5 of the list of other modules in the stack trace
+ - an md5 o the datalad modules in the stack trace
+
+And then the [GitHub workflow](.github/workflows/report_issue.yml) generates a folder
+structure that has the same format:
+
+```
+issues/
+   Exception/
+     others-md5
+       datald-md5
+```
+
+And the CI checks if the issue has been previously opened based on these identifiers.
+
+## Submit
+
+Next, here is an example of running the helper headlessly. Note that this will currently still confirm the
 environment variables being sent from the user.
 
 ```python
-issue = helper.run_headless(repo=repo, body=body, title=title)
+identifier = "Exception-others-<md5>-datald-<md5>"
+issue = helper.run_headless(repo=repo, body=body, title=title, identifier=identifier, generate_md5=False)
 ```
 
 The above will still require confirmation to send the user environment,
-and then will post the issue to `datalad/datalad-support`. If there is no GitHub
+and then will post the issue to `datalad/datalad-helpme`. If there is no GitHub
 token provided in the environment, the user can fill in the sections to complete the issue.
 Otherwise, the issue could be submit automatically and the response from the GitHub
 API would be returned.


### PR DESCRIPTION
This is a first shot at adding the parser as a GitHub action to, when an issue is submit:

 - obtain the unique identifier, an md5 of the traceback from the new issue
 - look through the record of currently existing issues, represented as a folder structure in the repository
 - post a comment / update the issue if it's already been opened.

This should serve two fold - to both help the user, and keep a little database of issues reported. I suspect we will want to get a base merged, and then tweak details once the datalad PR is merged and we can adjust.